### PR TITLE
Fix memory corruption bugs

### DIFF
--- a/Fission.cpp
+++ b/Fission.cpp
@@ -27,6 +27,8 @@ int Fission::run(int argc, char* argv[]) {
 	std::ifstream src;
 	bool skipShebang = false;
 	std::unordered_map<std::string, std::function<int()>> options;
+
+    trace = false;
 	
 	options["-s"] = options["--script"] = [&]() {
 		skipShebang = true;

--- a/Storage.h
+++ b/Storage.h
@@ -25,11 +25,11 @@ namespace fsn {
 	template <class T>
 	class Storage: public virtual Component {
 	public:
-		static const StoredData& getTop(std::stack<StoredData> stack) {
+		static const StoredData& getTop(std::stack<StoredData>& stack) {
 			return stack.top();
 		}
 		
-		static const StoredData& getTop(std::queue<StoredData> queue) {
+		static const StoredData& getTop(std::queue<StoredData>& queue) {
 			return queue.front();
 		}
 		


### PR DESCRIPTION
The trace flag was not initialised if there the command-line option is
not set.

More importantly, the stacks and queues in Storage::getTop were passed
by value, such that the memory was already free'd by the time the values
are copied into the atom, leading to all sorts of memory corruption and
nasal demons.
