### PR TITLE
making it compile for TIO

### DIFF
--- a/Grid.cpp
+++ b/Grid.cpp
@@ -17,6 +17,7 @@
 #include <set>
 #include <unordered_set>
 #include <unistd.h>
+#include <limits.h>
 #include "macros.h"
 #include "tokens.h"
 #include "Atom.h"


### PR DESCRIPTION
It seems to require limits.h to compile here on tio with `clang *.cpp -std=gnu++11 -lstdc++ -o fission` otherwise it gives :

```
Grid.cpp:43:20: error: use of undeclared identifier 'INT_MAX'
                if(line.size() > INT_MAX) {
                                 ^
1 error generated.
```
Please merge, or advise how to compile properly.
